### PR TITLE
Newlines and tabs are preceded by a backslash

### DIFF
--- a/ht/test_dataset.txt
+++ b/ht/test_dataset.txt
@@ -2,7 +2,10 @@ yosemite	california
 arches	utah
 badlands	north dakota
 everglades	miami
-tes\\nting	new\\nline
+tes\
+ting	new\
+line
 	
-tes\\ting	t\\tab
+tes\	ting	t\	tab
 com,ma park	oregon
+testing\\	back\\slash\\


### PR DESCRIPTION
In your test dataset, newlines and tabs were turned into \\n and \\t.  However the challenge is to handle the case where they are simply preceded by a backslash.  Also you need to handle cases of actual backslashes being escaped, especially right before column and row delimiters.

See my changes to the test dataset.